### PR TITLE
Fix displaying HTML URLs

### DIFF
--- a/src/messagewidget.cpp
+++ b/src/messagewidget.cpp
@@ -5,7 +5,6 @@
 #include "cache.h"
 #include "requesthandler.h"
 
-#include <QRegularExpression>
 #include <QLocale>
 #include <QSize>
 #include <QEventLoop>
@@ -49,7 +48,11 @@ MessageWidget::MessageWidget(MessageItem * item, QIcon icon, QWidget *parent) :
     if (!image.isNull()) {
         setImage(image);
     } else {
-        ui->label_message->setText(replaceLinks(item->message()));
+        QString text = item->message();
+        if (!Utils::containsHtml(item->message()) && !item->markdown())
+            text = Utils::replaceLinks(item->message());
+
+        ui->label_message->setText(text);
         if (item->markdown())
             ui->label_message->setTextFormat(Qt::MarkdownText);
     }
@@ -167,11 +170,4 @@ void MessageWidget::setPriorityColor(int priority)
         ui->label_priority->setStyleSheet("background-color: #b3e67e22;");
     else if (priority > 7)
         ui->label_priority->setStyleSheet("background-color: #e74c3c;");
-}
-
-
-QString MessageWidget::replaceLinks(QString text)
-{
-    static QRegularExpression re("(https?)(://\\S+)");
-    return text.replace(re, "<a href=\"\\1\\2\">\\1\\2</a>");
 }

--- a/src/messagewidget.h
+++ b/src/messagewidget.h
@@ -35,7 +35,6 @@ private:
     QNetworkAccessManager * manager;
 
     void setImage(QString url);
-    QString replaceLinks(QString text);
     void setPriorityColor(int priority);
 };
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -84,8 +84,23 @@ extractImage(QString text)
     return QString();
 }
 
-QString
-getUuid()
+
+QString replaceLinks(QString text)
+{
+    static QRegularExpression re("(https?)(://\\S+)");
+    return text.replace(re, "<a href='\\1\\2'>\\1\\2</a>");
+}
+
+
+bool containsHtml(QString text)
+{
+    static QRegularExpression regex(R"(<([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>.*<\/\1>)");
+    QRegularExpressionMatch matchHTML = regex.match(text);
+    return matchHTML.hasMatch();
+}
+
+
+QString getUuid()
 {
     return QUuid::createUuid().toString(QUuid::Id128);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -25,6 +25,12 @@ QString
 extractImage(QString text);
 
 QString
+replaceLinks(QString text);
+
+bool
+containsHtml(QString text);
+
+QString
 getUuid();
 
 bool


### PR DESCRIPTION
encapsulate urls with html tags only when no html and no markdown

closes #5 