### PR TITLE
Revert icon upon middle click

### DIFF
--- a/src/mainapplication.cpp
+++ b/src/mainapplication.cpp
@@ -191,6 +191,9 @@ void MainApplication::trayActivated(QSystemTrayIcon::ActivationReason reason)
     if (reason == QSystemTrayIcon::ActivationReason::Trigger) {
         mainWindow->bringToFront();
     }
+    if (reason == QSystemTrayIcon::ActivationReason::MiddleClick) {
+        tray->revertIcon();
+    }
 }
 
 


### PR DESCRIPTION
This one-liner reverts the icon to the previous one if the user clicks on it with the middle mouse button.

Tested on KDE.